### PR TITLE
various small updates: javadoc, ActivityLogger signature has Activity…

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@
 The "create a framework" statement in the assignment instructions made me think about something that could
 potentially be used in the EDR agent test-suite, such as a library. Therefore, I kept dependencies
 minimal and tried to design it such that client code would have options regarding how to use the classes. However, since
-the requirements mention the program triggering activities, I added a CLI for demonstration & testing (see **Main**). The CLI
+the requirements mention the program triggering activities, I added a CLI for demonstration & testing (see **Main**).
+The CLI
 could be removed, the project could be built as a library, a webservice interface could be added, etc.
 
 The **ActivityGenerator** and **JsonActivityLogger** are the core classes.
 The **Activity** models serve as both the contract between modules and as a schema for data types of the log file.
 If a new field is to be added to the log file, it can be added to the model and set in the Generator. The Logger does
 not need to change. I chose the approach of using an existing object mapper for speed of development and the fact that
-Jackson library has support for csv, yaml, & others. Therefore, support for additional log file types could be added easily.
-
-
+Jackson library has support for csv, yaml, & others. Therefore, support for additional log file types could be added
+easily.
 
 ### Build & Run
 
@@ -34,7 +34,8 @@ or, if necessary
 mvn package -Dmaven.test.skip
 ````
 
-from the root project directory will generate **activity-generator-1.0-SNAPSHOT-jar-with-dependencies.jar** in the **./target** directory.
+from the root project directory will generate **activity-generator-1.0-SNAPSHOT-jar-with-dependencies.jar** in the **
+./target** directory.
 
 The jar file can be executed like so:
 
@@ -75,9 +76,10 @@ usage: activity-generator
 - [ ] consider allow list for executable files
 - [ ] review error handling
 - [ ] integration tests
-- [ ] considerations for log roll over, safeguards for creating two loggers with same log file path
-- [ ] changes are needed for some tests to be system independent
+- [ ] harden unit tests (sad path, edge cases, etc)
+- [ ] changes are needed for some tests to be system independent 
 - [ ] mac testing
+- [ ] considerations for log roll over, safeguards for creating two loggers with same log file path, etc
 
 #### Known Issues
 

--- a/src/main/java/activities/FileActivity.java
+++ b/src/main/java/activities/FileActivity.java
@@ -4,6 +4,10 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 @JsonSerialize
 public class FileActivity extends Activity {
+
+    public static final String DESCRIPTOR_CREATE = "CREATE";
+    public static final String DESCRIPTOR_MODIFY = "MODIFY";
+    public static final String DESCRIPTOR_DELETE = "DELETE";
     private String filePath;
     private String descriptor;
 

--- a/src/main/java/generator/ActivityGenerator.java
+++ b/src/main/java/generator/ActivityGenerator.java
@@ -20,9 +20,6 @@ import java.util.List;
  * Class to perform activities on the host system and generate data describing the activities.
  */
 public class ActivityGenerator {
-    private static final String DESCRIPTOR_CREATE = "CREATE";
-    private static final String DESCRIPTOR_MODIFY = "MODIFY";
-    private static final String DESCRIPTOR_DELETE = "DELETE";
     private static final String NONE = "";
 
     /**
@@ -66,7 +63,7 @@ public class ActivityGenerator {
      */
     public FileActivity writeFile(Path path) throws IOException {
         FileActivity fileActivity = new FileActivity();
-        fileActivity.setDescriptor(DESCRIPTOR_CREATE);
+        fileActivity.setDescriptor(FileActivity.DESCRIPTOR_CREATE);
         String timestamp = Instant.now().toString();
         fileActivity.setTimestamp(timestamp);
         Path created = Files.createFile(path);
@@ -85,7 +82,7 @@ public class ActivityGenerator {
      */
     public FileActivity modifyFile(Path path, byte[] modification) throws IOException {
         FileActivity fileActivity = new FileActivity();
-        fileActivity.setDescriptor(DESCRIPTOR_MODIFY);
+        fileActivity.setDescriptor(FileActivity.DESCRIPTOR_MODIFY);
         String timestamp = Instant.now().toString();
         fileActivity.setTimestamp(timestamp);
         Path modified = Files.write(path, modification, StandardOpenOption.APPEND);
@@ -103,7 +100,7 @@ public class ActivityGenerator {
      */
     public FileActivity deleteFile(Path path) throws IOException {
         FileActivity fileActivity = new FileActivity();
-        fileActivity.setDescriptor(DESCRIPTOR_DELETE);
+        fileActivity.setDescriptor(FileActivity.DESCRIPTOR_DELETE);
         String timestamp = Instant.now().toString();
         fileActivity.setTimestamp(timestamp);
         Files.delete(path);
@@ -129,7 +126,7 @@ public class ActivityGenerator {
      * @param protocol The protocol to be used for the network connection.
      * @param message  The data to be sent to the destination.
      * @return NetworkActivity
-     * @throws IOException if file IO fails (ex file doesn't exist)
+     * @throws IOException if network IO fails (ex can't establish connection)
      */
     public NetworkActivity connect(String destIp, int destPort, Protocol protocol, String message) throws IOException {
         NetworkActivity netActivity = new NetworkActivity();

--- a/src/main/java/logger/ActivityLogger.java
+++ b/src/main/java/logger/ActivityLogger.java
@@ -1,7 +1,9 @@
 package logger;
 
+import activities.Activity;
+
 public interface ActivityLogger extends AutoCloseable {
 
-    void logActivity(Object activity) throws ActivityParseException;
+    void logActivity(Activity activity) throws ActivityParseException;
 
 }

--- a/src/main/java/logger/JsonActivityLogger.java
+++ b/src/main/java/logger/JsonActivityLogger.java
@@ -1,5 +1,6 @@
 package logger;
 
+import activities.Activity;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -14,7 +15,8 @@ public class JsonActivityLogger implements ActivityLogger {
     private final Path logFile;
     private boolean firstLine = true;
 
-    //TODO considerations for log roll over, safeguards for creating two loggers with same log file path, etc
+    //TODO considerations for log roll over, safeguards for creating two loggers with same log file path,
+    // line separator included or not, etc
     public JsonActivityLogger(ObjectMapper mapper, Path logFile) {
         this.mapper = mapper;
         try {
@@ -28,12 +30,13 @@ public class JsonActivityLogger implements ActivityLogger {
     }
 
     /**
+     * Writes a single activity to the log.
      * Log writes are not synchronized by this class. This method should be called serially.
      *
      * @param activity data to be written to the log
      */
     @Override
-    public void logActivity(Object activity) throws ActivityParseException {
+    public void logActivity(Activity activity) throws ActivityParseException {
         try {
             String actString = mapper.writeValueAsString(activity);
             if (!firstLine) {


### PR DESCRIPTION
… parent class rather than object (more firm contract & is clear that it doesn't take lists/batches of activities), & moved descriptor fields to file activity.